### PR TITLE
Fix deprecated actions/upload-artifact error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> $GITHUB_ENV
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: shamir-cli-${{ matrix.goos }}-${{ matrix.goarch }}
         path: ${{ env.ARCHIVE_NAME }}
@@ -127,7 +127,7 @@ jobs:
         echo "Version: $VERSION"
         
     - name: Download all artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
         


### PR DESCRIPTION
Update `actions/upload-artifact` and `actions/download-artifact` to v4 to resolve deprecation errors.