### PR TITLE
Troubleshoot GitHub release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, master ]
     tags: [ 'v*' ]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   test:
     name: Test before release
@@ -111,6 +115,10 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     
+    permissions:
+      contents: write
+      packages: write
+    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -135,7 +143,7 @@ jobs:
       run: ls -R artifacts
       
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Add write permissions to GitHub Actions workflow and update release action to resolve 403 errors during release creation.